### PR TITLE
Fix #10 _get_source() takes at least 6 arguments

### DIFF
--- a/jasper_reports/report_xml.py
+++ b/jasper_reports/report_xml.py
@@ -220,9 +220,10 @@ class report_xml(models.Model):
             name = False
             if language:
                 # Obtain field string for user's language.
-                name = pool.get('ir.translation'
-                                )._get_source(modelName + ',' + field,
-                                              'field', language)
+                # name = pool.get('ir.translation'
+                #                 )._get_source(modelName + ',' + field,
+                #                               'field', language)
+                name = pool.get('ir.translation')._get_source(self._cr, self._uid, modelName + ',' + field, 'field', language)
             if not name:
                 # If there's not description in user's language,
                 # use default (english) one.


### PR DESCRIPTION
Hi, 
This pull request is about fixing the module when running the creation of new template wizard on odoo8 which uses the new api. Accordingly, it raises the same error reported on  #10     
