### PR TITLE
[FIX] Float null value

### DIFF
--- a/jasper_reports/JasperReports/BrowseDataGenerator.py
+++ b/jasper_reports/JasperReports/BrowseDataGenerator.py
@@ -373,7 +373,8 @@ class CsvBrowseDataGenerator(BrowseDataGenerator):
                           subsequence, copy):
         # One field (many2one, many2many or one2many) can appear several times
         # Process each "root" field only once by using a set.
-        unrepeated = set([field.partition('/')[0] for field in fields])
+        field_type = False
+        unrepeated = set( [field.partition('/')[0] for field in fields] )
         for field in unrepeated:
             root = field.partition('/')[0]
             if path:
@@ -465,8 +466,11 @@ class CsvBrowseDataGenerator(BrowseDataGenerator):
                 # Check for field 'id' because we can't find it's
                 # type in _columns
                 value = str(value)
-            elif value in (False, None):
-                value = ''
+            elif value in (False,None):
+                if field_type and field_type == 'float':
+                    value = 0.0
+                else:
+                    value = ''
             elif field_type == 'date':
                 value = '%s 00:00:00' % str(value)
             elif field_type == 'binary':


### PR DESCRIPTION
Hello!

I've been suffering the float NULL error when its 0.00 since I can remember. I decided to make a minor change when its generating CSV data, python understands 0.0 like False wich is cool for python but it creates NULL doubles and send them to jasper, which is pretty difficult to manage and the only solution is to do shitty workarounds.

I don't know if this solves the entire problem but its good for me, so if anyone feels frustated and find this can give him hope.

PS: This only applies on XML TEMPLATE based JASPERs, not SQL.